### PR TITLE
IMX: do_hab calls strcat on uninitialised memory

### DIFF
--- a/scripts/imx/imx.c
+++ b/scripts/imx/imx.c
@@ -310,7 +310,7 @@ static int do_hab(struct config_data *data, int argc, char *argv[])
 	if (!data->csf) {
 		data->csf_space = 0x10000;
 
-		data->csf = malloc(data->csf_space + 1);
+		data->csf = calloc(data->csf_space + 1, 1);
 		if (!data->csf)
 			return -ENOMEM;
 	}


### PR DESCRIPTION
Buffer was allocated via malloc and then added to using strcat. This could result in some invalid data being passed to CST (CST was generally quite good at ignoring it but sometimes it would fail).