### PR TITLE
usb: dwc3: support snps,dis-u2-freeclk-exists-quirk for i.MX8MP

### DIFF
--- a/drivers/usb/dwc3/core.c
+++ b/drivers/usb/dwc3/core.c
@@ -1001,6 +1001,8 @@ static void dwc3_get_properties(struct dwc3 *dwc)
 	dwc->dr_mode = of_usb_get_dr_mode(dev->device_node, NULL);
 	dwc->hsphy_mode = of_usb_get_phy_mode(dev->device_node, NULL);
 
+	dwc->dis_u2_freeclk_exists_quirk = of_property_read_bool(dev->device_node,
+		"snps,dis-u2-freeclk-exists-quirk");
 	dwc->lpm_nyet_threshold = lpm_nyet_threshold;
 	dwc->tx_de_emphasis = tx_de_emphasis;
 


### PR DESCRIPTION
 The driver currently configures the Synopsis USB 3.0/2.0 PHY to
 unconditionally provide a free-running PHY clock. This must
 be disabled on the i.MX8MP as well as RK3328 and RK3399 SoC,
 because the clock control input is inactive.

 The upstream Linux binding specifies a boolean DT property
 snps,dis-u2-freeclk-exists-quirk to disable the free-running
 PHY clock and the property is already used in the i.MX8MP
 DT, that barebox imports from upstream. Thus implement the
 binding for barebox. This fixes barebox USB host support on the
 i.MX8MP, which previously triggered a BUG() when enumerating[1].

 Link: https://github.com/saschahauer/barebox/issues/13 [1]
 Fixes: e213627bbe1d ("usb: dwc3: of-simple: add i.MX8MP compatible")
 Signed-off-by: Hans Christian Lønstad <hcl@datarespons.no>

Reviewed-by: Ahmad Fatoum <a.fatoum@pengutronix.de>