### PR TITLE
imx8mp.dtsi: Correct wrong references to power/clock

### DIFF
--- a/arch/arm/dts/imx8mp.dtsi
+++ b/arch/arm/dts/imx8mp.dtsi
@@ -7,3 +7,23 @@
 		syscon = <&src>;
 	};
 };
+
+&flexspi {
+	clock-names = "fspi_en", "fspi";
+};
+
+&usb3_0 {
+	power-domains = <&pgc_hsiomix>;
+};
+
+&usb3_1 {
+	power-domains = <&pgc_hsiomix>;
+};
+
+&usb3_phy0 {
+	power-domains = <&pgc_usb1_phy>;
+};
+
+&usb3_phy1 {
+	power-domains = <&pgc_usb2_phy>;
+};


### PR DESCRIPTION
Imported kernel tree for IMX8MP contains the following errors:

For the IMX8MP the power-domain references does not refer to an _actual_ power domain. This breaks USB as probe call will fail. The correct power domain is pgc_hsiomix.

Flexspi clocks misnamed as "qspi" and "qspi_en" leading to probe error. The Flexspi driver uses clock names "fspi" and "fspi_en" as is the case for all IMX8 familiy members employing this IP block.

Signed-off-by: Hans Christian Lonstad <hcl@datarespons.com>