### PR TITLE
/arch/arm/dts: imx8mp: Do not mask out mediamix power domain

### DIFF
--- a/arch/arm/dts/imx8mp.dtsi
+++ b/arch/arm/dts/imx8mp.dtsi
@@ -51,10 +51,6 @@ feat: &ocotp {
 	barebox,feature-gates = <&feat IMX8M_FEAT_GPU>;
 };
 
-&pgc_mediamix {
-	barebox,feature-gates = <&feat IMX8M_FEAT_ISP>;
-};
-
 &pgc_mipi_phy2 {
 	barebox,feature-gates = <&feat IMX8M_FEAT_MIPI_DSI>;
 };


### PR DESCRIPTION
This domain is consumed by generic display resources unrelated to the existence of the ISP. Masking it breaks the IMX8MP Lite.

Fixes: https://github.com/barebox/barebox/issues/20