### PR TITLE
ARCH_IMX8M: Re-enable hidden features

### DIFF
--- a/arch/arm/mach-imx/Kconfig
+++ b/arch/arm/mach-imx/Kconfig
@@ -720,7 +720,7 @@ config HABV4
 	select HAB
 	select NVMEM
 	select IMX_OCOTP
-	depends on ARCH_IMX6 || ARCH_IMX8MQ
+	depends on ARCH_IMX6 || ARCH_IMX8M
 	depends on OFDEVICE
 	help
 	  High Assurance Boot, as found on i.MX28/i.MX6/i.MX8MQ.

--- a/drivers/hab/hab.c
+++ b/drivers/hab/hab.c
@@ -208,7 +208,7 @@ static struct imx_hab_ops *imx_get_hab_ops(void)
 
 	if (IS_ENABLED(CONFIG_HABV3) && (cpu_is_mx25() || cpu_is_mx35()))
 		tmp = &imx_hab_ops_iim;
-	else if (IS_ENABLED(CONFIG_HABV4) && (cpu_is_mx6() || cpu_is_mx8mq()))
+	else if (IS_ENABLED(CONFIG_HABV4) && (cpu_is_mx6() || cpu_is_mx8m()))
 		tmp = &imx_hab_ops_ocotp;
 	else
 		return NULL;

--- a/drivers/pci/Kconfig
+++ b/drivers/pci/Kconfig
@@ -43,7 +43,8 @@ config PCI_TEGRA
 
 config PCI_IMX6
 	bool "Freescale i.MX6/7/8 PCIe controller"
-	depends on ARCH_IMX6 || ARCH_IMX7 || ARCH_IMX8MQ
+	depends on ARCH_IMX6 || ARCH_IMX7 || ARCH_IMX8MQ || ARCH_IMX8MP
+	select PCIE_DW
 	select PCIE_DW
 	select OF_PCI
 	select PCI

--- a/drivers/regulator/Kconfig
+++ b/drivers/regulator/Kconfig
@@ -20,7 +20,7 @@ config REGULATOR_BCM283X
 config REGULATOR_PFUZE
 	bool "Freescale PFUZE100/200/3000 regulator driver"
 	depends on I2C
-	depends on ARCH_IMX6 || ARCH_IMX8MQ
+	depends on ARCH_IMX6 || ARCH_IMX8M
 
 config REGULATOR_STM32_PWR
 	bool "STMicroelectronics STM32 PWR"


### PR DESCRIPTION
https://github.com/barebox/barebox/issues/23

IMX8M(P) supports functinality masked by
ARCH_IMX8MQ and corresponding is_cpu.. functions.
HABv4 goes for ARCH_IMX8M and PCIe for ARCH_IMX8MP as well