### PR TITLE
net: usb: ax88179_178a.c: add missing poller unregister

### DIFF
--- a/drivers/net/usb/ax88179_178a.c
+++ b/drivers/net/usb/ax88179_178a.c
@@ -417,6 +417,9 @@ static int ax88179_bind(struct usbnet *dev)
 static void ax88179_unbind(struct usbnet *dev)
 {
 	u16 tmp16;
+	struct ax88179_priv *priv = dev->driver_priv;
+
+	poller_unregister(&priv->poller);
 
 	/* Configure RX control register => stop operation */
 	tmp16 = AX_RX_CTL_STOP;


### PR DESCRIPTION
Fix a possible barebox crash (~1/10), when using a USB-Ethernet-Adaptor, that uses the ax88179_178a driver.

Need to deregister the poller on unbind, otherwise the function might segfault on shutdown:

```
  unable to handle NULL pointer dereference at address 0x0000003c
  pc : [<4fe01824>]    lr : [<4fe2bf75>]
  sp : 4ffefae8  ip : 00000000  fp : 00000000
  r10: 00000002  r9 : 00000000  r8 : 0000003c
  r7 : 00000026  r6 : 00000002  r5 : 2fefac40  r4 : 0000003c
  r3 : 00000040  r2 : 00000001  r1 : d44a2100  r0 : 0000003c
  Flags: nzcv  IRQs off  FIQs off  Mode SVC_32
  [<4fe01824>] (slice_acquired+0xc/0x50) from [<4fe2bf75>] (usb_control_msg+0x31/0x9e)
  [<4fe2bf75>] (usb_control_msg+0x31/0x9e) from [<4fe11ed5>] (__ax88179_write_cmd+0x75/0xbc)
  [<4fe11ed5>] (__ax88179_write_cmd+0x75/0xbc) from [<4fe11f35>] (ax88179_write_cmd.part.0+0x19/0x1c)
  [<4fe11f35>] (ax88179_write_cmd.part.0+0x19/0x1c) from [<4fe12079>] (ax88179_mdio_read+0x1f/0x46)
  [<4fe12079>] (ax88179_mdio_read+0x1f/0x46) from [<4fe08259>] (poller_call+0x2d/0x44)
  [<4fe08259>] (poller_call+0x2d/0x44) from [<4fe08131>] (resched+0x29/0x40)
  [<4fe08131>] (resched+0x29/0x40) from [<4fe007e1>] (is_timeout+0x1d/0x24)
  [<4fe007e1>] (is_timeout+0x1d/0x24) from [<4fe148bd>] (fec_halt+0x45/0x84)
  [<4fe148bd>] (fec_halt+0x45/0x84) from [<4fe0f6b1>] (devices_shutdown+0x21/0x2c)
  [<4fe0f6b1>] (devices_shutdown+0x21/0x2c) from [<4fe0115d>] (shutdown_barebox+0x21/0x30)
  ...
```

It was enough to bring USB and the ethernet interface up and the boot anything. The patch was tested on 2025.01.0.