### PR TITLE
boards: qemu-virt: disable system1 in state by default

### DIFF
--- a/common/boards/qemu-virt/qemu-virt-flash.dtso
+++ b/common/boards/qemu-virt/qemu-virt-flash.dtso
@@ -80,13 +80,13 @@
 				remaining_attempts@8 {
 					reg = <0x8 0x4>;
 					type = "uint32";
-					default = <3>;
+					default = <0>;
 				};
 
 				priority@c {
 					reg = <0xc 0x4>;
 					type = "uint32";
-					default = <21>;
+					default = <0>;
 				};
 			};
 


### PR DESCRIPTION
In almost all cases, you want to boot from system0 if you've not written the state data yet.