### PR TITLE
scripts: bareboxtlv-generator: avoid private key access for public key extraction

### DIFF
--- a/scripts/bareboxtlv-generator/bareboxtlv-generator.py
+++ b/scripts/bareboxtlv-generator/bareboxtlv-generator.py
@@ -65,7 +65,7 @@ class PrivateKey:
             sys.exit(127)
 
         self.inkey = path
-        self.public_key = serialization.load_pem_public_key(openssl(["pkey", "-pubout", "-in", self.inkey]));
+        self.public_key = serialization.load_pem_public_key(openssl(["pkey", "-pubin", "-pubout", "-in", self.inkey]));
 
     def sign(self, message: bytes) -> bytes:
         """


### PR DESCRIPTION
Especially when using the pkcs11 provider, using only the public key as input (-pubin) avoids unnecessary PIN requests.