### PR TITLE
Fix Kbuild update regressions in v2026.08.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,8 @@ endif
 need-compiler := $(may-sync-config)
 
 ifeq ($(KBUILD_EXTMOD),)
-    ifneq ($(filter %config,$(MAKECMDGOALS)),)
+    # security_%config targets configure security policies, not .config
+    ifneq ($(filter-out security_%,$(filter %config,$(MAKECMDGOALS))),)
         config-build := 1
         ifneq ($(words $(MAKECMDGOALS)),1)
             mixed-build := 1
@@ -1339,7 +1340,7 @@ targets += include/generated/sconfig_names.h
 
 KPOLICY = $(shell find $(objtree)/ -name policy-list -exec cat {} \;)
 
-collect-dirs    := $(addprefix _policy_collect_,$(barebox-alldirs))
+collect-dirs    := $(addprefix _policy_collect_,$(build-dir))
 
 PHONY += _policy_collect_clean $(collect-dirs) collect-policies
 _policy_collect_clean:

--- a/defaultenv/Makefile
+++ b/defaultenv/Makefile
@@ -32,7 +32,7 @@ $(obj)/barebox_default_env.h: $(obj)/barebox_default_env$(bbenv-suffix-y) FORCE
 	$(call if_changed,env_h)
 
 quiet_cmd_env_zero = ENVZ    $@
-cmd_env_zero = ($(objtree)/scripts/bareboxenv -z "$(CONFIG_DEFAULT_ENVIRONMENT_PATH)" $@)
+cmd_env_zero = $(objtree)/scripts/bareboxenv -z "" $@
 
 $(obj)/barebox_zero_env: FORCE
 	$(call if_changed,env_zero)

--- a/scripts/Makefile.policy
+++ b/scripts/Makefile.policy
@@ -7,21 +7,20 @@
 ifndef build
 # Standalone mode — collect policies without building
 
-src := $(obj)
+src := $(srcroot)/$(obj)
 
 PHONY := __collect
 __collect:
 
 policy-y :=
 
-include scripts/Kbuild.include
+include $(srctree)/scripts/Kbuild.include
 
 # Include Kconfig output so CONFIG_* symbols (e.g. CONFIG_SECURITY_POLICY_PATH)
 # are available when security/Makefile computes external-policy.
 -include include/config/auto.conf
 
-kbuild-dir := $(if $(filter /%,$(src)),$(src),$(srctree)/$(src))
-include $(if $(wildcard $(kbuild-dir)/Kbuild), $(kbuild-dir)/Kbuild, $(kbuild-dir)/Makefile)
+include $(kbuild-file)
 
 __subdir-y	:= $(patsubst %/,%,$(filter %/, $(obj-y)))
 subdir-y	+= $(__subdir-y)


### PR DESCRIPTION
v2026.08.0 was our first release after the Kbuild update and it was found to trigger some breakage in Yocto BSPs. Fixes are already in master, so cherry-pick them for a stable release.