### PR TITLE
state: warn when direct buckets on block devices are not block aligned

### DIFF
--- a/Documentation/devicetree/bindings/barebox/barebox,state.rst
+++ b/Documentation/devicetree/bindings/barebox/barebox,state.rst
@@ -67,17 +67,16 @@ Optional Properties
 
 The ``backend-stridesize`` is still optional but required whenever the
 underlying backend doesn't provide an information how to pad an instance of a
-*state* variable set. This is valid for all underlying backends which support
-writes on a byte-by-byte manner or don't have eraseblocks (EEPROM, SRAM and NOR
-type flash backends).
+*state* variable set. This is valid for all underlying backends which don't
+have eraseblocks (EEPROM, SRAM, MRAM and block devices like eMMC and SD cards).
 The ``backend-stridesize`` value is used by the ``direct`` backend storage type
 to place the redundant *state* variable set copies side by side in the backend.
-And it's used by the ``circular`` backend storage type to place the *state*
-variable set copies side by side into the eraseblock.
+The ``circular`` backend storage type ignores it: it packs the *state*
+variable set copies into the eraseblock at the write granularity reported by
+the MTD device.
 You should calculate the ``backend-stridesize`` value very carefully based on
-the used ``backend-type``, the size of the used backend (e.g. partition size
-for example) and its eraseblock size. Refer
-:ref:`Backend Types <state_framework,backend_types>`.
+the used ``backend-type`` and the size of the used backend (e.g. partition size
+for example). Refer :ref:`Backend Types <state_framework,backend_types>`.
 
 .. note:: It might be useful to add some spare space to the
    ``backend-stridesize`` to ensure the ability to extend the *state* variable

--- a/Documentation/devicetree/bindings/barebox/barebox,state.rst
+++ b/Documentation/devicetree/bindings/barebox/barebox,state.rst
@@ -78,6 +78,14 @@ You should calculate the ``backend-stridesize`` value very carefully based on
 the used ``backend-type`` and the size of the used backend (e.g. partition size
 for example). Refer :ref:`Backend Types <state_framework,backend_types>`.
 
+.. important:: On block devices the ``backend-stridesize`` must be a multiple
+   of the block size (usually 512 bytes) and the backend partition must be
+   block aligned. Otherwise multiple copies of the *state* variable set
+   share a block and an interrupted write can corrupt more than one copy,
+   which defeats the redundancy. barebox warns at startup if this is the
+   case. Byte-writable backends like EEPROM, SRAM or MRAM have no such
+   constraint.
+
 .. note:: It might be useful to add some spare space to the
    ``backend-stridesize`` to ensure the ability to extend the *state* variable
    set later on.

--- a/Documentation/user/state.rst
+++ b/Documentation/user/state.rst
@@ -373,11 +373,10 @@ Circular Storage Backend Redundancy
 
 Redundant copies of the *state* variable set are stored based on the memory's
 eraseblocks and this size is automatically detected at run-time.
-It needs a stride size as well, because a NOR type flash memory can be written
-on a byte-by-byte manner.
-In contrast to the ``direct`` storage backend redundancy, the
-stride size for the ``circular`` storage backend redundancy defines the
-side-by-side location of the *state* variable set copies.
+The stride size is not used. Since NOR type flash memory can be written on a
+byte-by-byte manner, the *state* variable set copies are packed back to back
+inside the eraseblock, each padded to the write granularity reported by the
+MTD device (at least 8 bytes).
 
 .. code-block:: text
 
@@ -388,7 +387,8 @@ side-by-side location of the *state* variable set copies.
     |<--------- eraseblock --------->|<--------- eraseblock --------->|<-
     |<------- redundant area ------->|<------- redundant area ------->|<-
 
-*<X>* defines the stride size, *C#1*, *C#2* the *state* variable set copies.
+*<X>* is the size of one copy rounded up to the write granularity, *C#1*, *C#2*
+the *state* variable set copies.
 
 Since these kinds of MTD devices are partitioned, it's a good practice to always
 reserve multiple eraseblocks for the barebox' *state* feature. Keep in mind:

--- a/Documentation/user/state.rst
+++ b/Documentation/user/state.rst
@@ -119,7 +119,9 @@ embedded *state* variable set. Refer to
    operating systems.
 
 .. note:: When calculating the ``backend-stridesize`` take the header overhead
-   into account. The header overhead is always 16 bytes.
+   into account. The header overhead is always 16 bytes. On block devices
+   the stride must additionally be a multiple of the block size, refer
+   :ref:`Direct Storage Backend Redundancy <state_framework,direct_redundancy>`.
 
 .. _state_framework,dtb:
 
@@ -337,6 +339,8 @@ In the case of an interruption and/or power loss resulting in an incomplete
 write to the backend, the system can fall back to a different *state* variable
 set copy (previous *state* variable set).
 
+.. _state_framework,direct_redundancy:
+
 Direct Storage Backend Redundancy
 #################################
 
@@ -365,6 +369,21 @@ size of a partition).
    The minimum size for the backend partition is then 44 * 3 = 132 bytes.
    It's a good idea though to increase stride size beyond the minimum to leave
    some free space for in-place addition of new variables in future.
+
+.. important:: The redundancy only helps if an interrupted write can damage
+   just the copy being written.
+   The stride size must therefore be a multiple of the block size and the
+   backend partition must start on a block boundary, otherwise two copies
+   share a block and a power loss during a write can corrupt both.
+   barebox warns at startup when this is the case.
+   Increasing the stride size on an already deployed device is deemed safe,
+   even across a power loss: the first copy always stays at the start of
+   the backend and is not rewritten during the migration, so it
+   remains readable while the other copies are rewritten at their new
+   positions on the next load. This requires the new stride size to be a
+   multiple of that atomically written block size, otherwise rewriting a copy
+   during the migration can damage the first copy.
+   Byte-writable backends like EEPROM, SRAM or MRAM have no such constraint.
 
 Circular Storage Backend Redundancy
 ###################################

--- a/Documentation/user/state.rst
+++ b/Documentation/user/state.rst
@@ -586,7 +586,7 @@ as follows:
 		magic = <0xab67421f>;
 		backend-type = "raw";
 		backend = <&backend_state_sd>;
-		backend-stridesize = <0x40>;
+		backend-stridesize = <0x200>;
 
 		variable@0 {
 			reg = <0x0 0x1>;

--- a/arch/arm/dts/stm32mp157c-lxa-mc1.dts
+++ b/arch/arm/dts/stm32mp157c-lxa-mc1.dts
@@ -35,7 +35,7 @@
 		/* backend is fixed up by board code */
 		backend-type = "raw";
 		backend-storage-type = "direct";
-		backend-stridesize = <0x40>;
+		backend-stridesize = <0x1000>;
 
 		#include "bootstate.dtsi"
 	};

--- a/common/state/state.c
+++ b/common/state/state.c
@@ -597,6 +597,43 @@ static char *cdev_to_devpath(struct cdev *cdev, off_t *offset, size_t *size)
 
 	return basprintf("/dev/%s", cdev->name);
 }
+
+/*
+ * state_check_stride_alignment - warn about strides that share a write unit
+ *
+ * The direct storage backend relies on a torn write only ever damaging the
+ * bucket being written. On block devices the smallest independently
+ * writable unit is a block, so both the stride and the backend offset must
+ * be block aligned for the redundant copies to be really independent.
+ * Byte-writable backends like EEPROMs or SRAM have no such constraint.
+ */
+static void state_check_stride_alignment(struct state *state, struct cdev *cdev,
+					 uint32_t stridesize)
+{
+	struct block_device *blk = cdev_get_block_device(cdev);
+	unsigned int blocksize;
+
+	if (!blk || !stridesize)
+		return;
+
+	blocksize = BLOCKSIZE(blk);
+
+	if (!IS_ALIGNED(stridesize, blocksize))
+		dev_warn(&state->dev,
+			 "backend-stridesize %u is not a multiple of the %u byte block size of %s, interrupted writes may corrupt more than one copy\n",
+			 stridesize, blocksize, cdev->name);
+
+	if (!IS_ALIGNED(cdev->offset, blocksize))
+		dev_warn(&state->dev,
+			 "backend offset %llu on %s is not aligned to its %u byte block size, interrupted writes may corrupt more than one copy\n",
+			 (unsigned long long)cdev->offset, cdev->name, blocksize);
+}
+#else
+static inline void state_check_stride_alignment(struct state *state,
+						struct cdev *cdev,
+						uint32_t stridesize)
+{
+}
 #endif
 
 static guid_t barebox_state_partition_guid = BAREBOX_STATE_PARTITION_GUID;
@@ -679,6 +716,8 @@ struct state *state_new_from_node(struct device_node *node, bool readonly)
 	}
 
 	of_property_read_string(node, "backend-storage-type", &storage_type);
+
+	state_check_stride_alignment(state, cdev, stridesize);
 
 	state->keep_prev_content = of_property_read_bool(node,
 							"keep-previous-content");


### PR DESCRIPTION
The direct storage backend keeps three copies of the state and relies on an interrupted write only ever damaging the copy that was being  written. On a block device the smallest independently writable unit is a block, so this only holds if backend-stridesize is a multiple of the block size and the backend partition starts on a block boundary.
Otherwise two copies share a block, a torn write of that block can take out both and the redundancy is gone.

Nothing enforced this so far: the block layer does a read-modify-write and a 64 byte stride on eMMC silently works, and several in-tree boards ship such a configuration.

This series documents this consideration and has barebox warn when the stride size was chosen unsuitably.